### PR TITLE
Exception fix and handling + better usability

### DIFF
--- a/src/main/java/com/achimala/leaguelib/errors/LeagueErrorCode.java
+++ b/src/main/java/com/achimala/leaguelib/errors/LeagueErrorCode.java
@@ -39,11 +39,18 @@ public enum LeagueErrorCode {
         return _exceptionString;
     }
 
+
     public static LeagueErrorCode getErrorCodeForException(String exceptionString) {
         if (exceptionString != null) {
             for (LeagueErrorCode code : LeagueErrorCode.values()) {
-                if (exceptionString.equals(code.getExceptionString())) {
-                    return code;
+                if (code.getExceptionString() != null) {
+                    if (exceptionString.contains(code.getExceptionString())) {
+                        return code;
+                    }
+                }else{
+                    if (exceptionString.equals(code.getExceptionString())) {
+                        return code;
+                    }
                 }
             }
         }

--- a/src/main/java/com/achimala/leaguelib/models/LeagueSummonerProfileInfo.java
+++ b/src/main/java/com/achimala/leaguelib/models/LeagueSummonerProfileInfo.java
@@ -29,8 +29,8 @@ public class LeagueSummonerProfileInfo {
         String s1 = obj.getString("seasonOneTier");
         String s2 = obj.getString("seasonTwoTier");
 
-        if (s1 != null) _seasonOneTier = LeagueRankedTier.valueOf(s1);
-        if (s2 != null) _seasonTwoTier = LeagueRankedTier.valueOf(s2);
+        if (s1 != "null") _seasonOneTier = LeagueRankedTier.valueOf(s1);
+        if (s2 != "null") _seasonTwoTier = LeagueRankedTier.valueOf(s2);
     }
 
     public void setSeasonOneTier(LeagueRankedTier tier) {

--- a/src/main/java/com/achimala/leaguelib/services/GameService.java
+++ b/src/main/java/com/achimala/leaguelib/services/GameService.java
@@ -39,6 +39,7 @@ public class GameService extends LeagueAbstractService {
     }
 
     // FIXME: Not sure if this is the right way to handle this
+    // FIXME: 01.01.2015, Kim-Maximilian Nuernberger: Applied workaround we should have an easy to use error object containing the rootcause.
     @Override
     protected TypedObject handleResult(TypedObject result) throws LeagueException {
         if(result.get("result").equals("_error")) {

--- a/src/test/java/com/achimala/leaguelib/MainTest.java
+++ b/src/test/java/com/achimala/leaguelib/MainTest.java
@@ -28,10 +28,9 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 // This tests pretty much everything. It downloads as much information as it can about a given summoner and displays it.
-// NOTE: You must pass in the password of the account(s) being used as a command line argument, so if someone pulls
-// this code and tries to run it, it's not going to work correctly out of the box.
-// If you're not one of the developers of this project, you'll want to change the account usernames and passwords below
-// to your own personal test accounts. (And change the summoner's name if you want).
+// You'll have to use a League of Legends account to pull the data from the servers.
+// NOTE: You must pass following commandline arguments to the program: <AccountName> <AccountPassword> <Summoner to lookup>
+// Summoner to lookup can have spaces in name, just write it as it is.
 public class MainTest {
     private static int count = 0;
     private static ReentrantLock lock = new ReentrantLock();
@@ -54,11 +53,19 @@ public class MainTest {
         lock.unlock();
     }
 
+    private static String getSummonerToLookupFromCommandLine(String[] args)
+    {
+        String name = "";
+        for(int i = 2; i < args.length; i++)
+            name += args[i] + " ";
+        return name.substring(0, name.length() -1);
+    }
+
     public static void main(String[] args) throws Exception {
         final LeagueConnection c = new LeagueConnection(ServerInfo.EUW);
         c.getAccountQueue().addAccount(new LeagueAccount(
-                ServerInfo.EUW, "4.21.14", "SoMuchLuckOmgReport", args[0]));
-        final String SUMMONER_TO_LOOK_UP = "LSC Krautsalat";
+                ServerInfo.EUW, "4.21.14", args[0], args[1]));
+        final String SUMMONER_TO_LOOK_UP = getSummonerToLookupFromCommandLine(args);
 
         Map<LeagueAccount, LeagueException> exceptions = c.getAccountQueue().connectAll();
         if(exceptions != null) {

--- a/src/test/java/com/achimala/leaguelib/MainTest.java
+++ b/src/test/java/com/achimala/leaguelib/MainTest.java
@@ -57,8 +57,8 @@ public class MainTest {
     public static void main(String[] args) throws Exception {
         final LeagueConnection c = new LeagueConnection(ServerInfo.EUW);
         c.getAccountQueue().addAccount(new LeagueAccount(
-                ServerInfo.EUW, "4.21.14", "Noobie3110", args[0]));
-        final String SUMMONER_TO_LOOK_UP = "Noobie3110";
+                ServerInfo.EUW, "4.21.14", "SoMuchLuckOmgReport", args[0]));
+        final String SUMMONER_TO_LOOK_UP = "LSC Krautsalat";
 
         Map<LeagueAccount, LeagueException> exceptions = c.getAccountQueue().connectAll();
         if(exceptions != null) {


### PR DESCRIPTION
Fixed the "No enum constant com.achimala.leaguelib.models.LeagueRankedTier.null" exception at runtime, applied workaround for exception handling fixing specific LeagueErrors as "Summoner not in Game" and "Game not spectateable".
Moved League account and "Summoner to lookup" from hardcoded string to commandline arguments for better usability and debugging.
